### PR TITLE
 Define raw_input() in Python 3

### DIFF
--- a/collect_data.py
+++ b/collect_data.py
@@ -1,11 +1,16 @@
+import os, numpy as np
+
 try:
 	import cv2
-except:
+except ImportError:
 	import sys
 	sys.path.append('/usr/local/lib/python2.7/site-packages')
 	import cv2
 
-import os, numpy as np
+try:
+	raw_input          # Python 2
+except NameError:
+	raw_input = input  # Python 3
 
 cap=cv2.VideoCapture(0)
 classifier=cv2.CascadeClassifier('./haarcascade_frontalface_default.xml')

--- a/test.py
+++ b/test.py
@@ -7,10 +7,15 @@ import time
 
 try:
 	import cv2
-except:
+except ImportError:
 	import sys
 	sys.path.append('/usr/local/lib/python2.7/site-packages')
 	import cv2
+
+try:
+	raw_input          # Python 2
+except NameError:
+	raw_input = input  # Python 3
 
 while True:
 	try:


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of a reworked version of __input()__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/dataplayer12/shavenet on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./collect_data.py:20:10: F821 undefined name 'raw_input'
	day_num=raw_input('Please enter days since last shaved: ')
         ^
./test.py:17:17: F821 undefined name 'raw_input'
		live_test=int(raw_input("Please enter 1 to test live and 0 to test on validation set: "))
                ^
./test.py:37:16: F821 undefined name 'raw_input'
			to_continue=raw_input("Please enter any key to continue and 'x' to stop:")
               ^
3     F821 undefined name 'raw_input'
3
```